### PR TITLE
[PATCH] Add support for positional arguments

### DIFF
--- a/cli-test/__tests__/__snapshots__/cli.js.snap
+++ b/cli-test/__tests__/__snapshots__/cli.js.snap
@@ -29,14 +29,6 @@ log
 }
 `;
 
-exports[`with silent option set true 1`] = `
-Object {
-  "stderr": "",
-  "stdout": "silent
-",
-}
-`;
-
 exports[`with a missing config 1`] = `
 Object {
   "stderr": "Unable to find JS config at \\"./something-that-does-not-exist.js\\". https://github.com/sezna/nps/blob/master/other/ERRORS_AND_WARNINGS.md#unable-to-find-config
@@ -54,11 +46,55 @@ default script
 }
 `;
 
+exports[`with multiple positional arguments 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "nps is executing \`multiple\` : echo \\"hello foo bar nps\\"
+hello foo bar nps
+",
+}
+`;
+
+exports[`with no positional arguments 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "nps is executing \`none\` : echo \\"hello nps\\" -- foo bar
+hello nps -- foo bar
+",
+}
+`;
+
 exports[`with prefix 1`] = `
 Object {
   "stderr": "",
   "stdout": "nps is executing \`lint.sub.thing.script\` : echo \\"deeply nested thing\\"
 deeply nested thing
+",
+}
+`;
+
+exports[`with second positional argument 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "nps is executing \`second\` : echo \\"hello bar nps\\" -- foo
+hello bar nps -- foo
+",
+}
+`;
+
+exports[`with silent option set true 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "silent
+",
+}
+`;
+
+exports[`with single positional argument 1`] = `
+Object {
+  "stderr": "",
+  "stdout": "nps is executing \`single\` : echo \\"hello foo nps\\"
+hello foo nps
 ",
 }
 `;

--- a/cli-test/__tests__/cli.js
+++ b/cli-test/__tests__/cli.js
@@ -22,6 +22,26 @@ test('with prefix', () => snapshot('--config ./package-scripts.js lint.s.t.s'))
 
 test('with --no-scripts', () => snapshot('test --no-scripts'))
 
+test('with single positional argument', () =>
+  snapshot(
+    '--config ./package-scripts-with-positional-args.js "single -- foo"',
+  ))
+
+test('with second positional argument', () =>
+  snapshot(
+    '--config ./package-scripts-with-positional-args.js "second -- foo bar"',
+  ))
+
+test('with multiple positional arguments', () =>
+  snapshot(
+    '--config ./package-scripts-with-positional-args.js "multiple -- foo bar"',
+  ))
+
+test('with no positional arguments', () =>
+  snapshot(
+    '--config ./package-scripts-with-positional-args.js "none -- foo bar"',
+  ))
+
 function snapshot(args) {
   return runNPS(fixturesPath, args).then(results => {
     const snapshottableResults = convertResultToLinuxSpecific(results)

--- a/cli-test/__tests__/fixtures/package-scripts-with-positional-args.js
+++ b/cli-test/__tests__/fixtures/package-scripts-with-positional-args.js
@@ -1,0 +1,8 @@
+module.exports = {
+  scripts: {
+    single: 'echo "hello $1 nps"',
+    second: 'echo "hello $2 nps"',
+    multiple: 'echo "hello $1 $2 nps"',
+    none: 'echo "hello nps"'
+  },
+}

--- a/src/__tests__/replace-positional-args.js
+++ b/src/__tests__/replace-positional-args.js
@@ -1,0 +1,25 @@
+import {replacePositionalArgs} from '../replace-positional-args'
+
+test('should return script and args if script undefined', () => {
+  expect(replacePositionalArgs(undefined, ['foo'])).toEqual([
+    undefined,
+    ['foo'],
+  ])
+})
+
+test('should return unmodified script and args if there are no positional args', () => {
+  expect(replacePositionalArgs('foobar', ['foo'])).toEqual(['foobar', ['foo']])
+})
+
+test('should replace positional args in the order specified', () => {
+  expect(replacePositionalArgs('foobar $2 $1', ['--', 'foo', 'bar'])).toEqual([
+    'foobar bar foo',
+    [],
+  ])
+})
+
+test('should throw if positional args required but not specified', () => {
+  expect(() => replacePositionalArgs('foobar $2 $1', [])).toThrow(
+    'Argument $2 not specified',
+  )
+})

--- a/src/__tests__/replace-positional-args.js
+++ b/src/__tests__/replace-positional-args.js
@@ -18,6 +18,12 @@ test('should replace positional args in the order specified', () => {
   ])
 })
 
+test('should allow using positional args multiple times', () => {
+  expect(
+    replacePositionalArgs('foobar $1 $2 $1', ['--', 'foo', 'bar']),
+  ).toEqual(['foobar foo bar foo', []])
+})
+
 test('should throw if positional args required but not specified', () => {
   expect(() => replacePositionalArgs('foobar $2 $1', [])).toThrow(
     'Argument $2 not specified',

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import spawn from 'spawn-command-with-kill'
 import chalk from 'chalk'
 import {oneLine} from 'common-tags'
-import {isString, clone, reduce} from 'lodash'
+import {isString, clone} from 'lodash'
 import {sync as findUpSync} from 'find-up'
 import managePath from 'manage-path'
 import arrify from 'arrify'

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
 import spawn from 'spawn-command-with-kill'
 import chalk from 'chalk'
 import {oneLine} from 'common-tags'
-import {isString, clone} from 'lodash'
+import {isString, clone, reduce} from 'lodash'
 import {sync as findUpSync} from 'find-up'
 import managePath from 'manage-path'
 import arrify from 'arrify'
 import getScriptToRun from './get-script-to-run'
 import getScriptsFromConfig from './get-scripts-from-config'
 import getLogger, {getLogLevel} from './get-logger'
+import {replacePositionalArgs} from './replace-positional-args'
 
 const NON_ERROR = 0
 
@@ -56,7 +57,8 @@ function runPackageScript({scriptConfig, options, input}) {
       ref: 'missing-script',
     })
   }
-  const command = [script, ...args].join(' ').trim()
+  const [newScript, reducedArgs] = replacePositionalArgs(script, args)
+  const command = [newScript, ...reducedArgs].join(' ').trim()
   const log = getLogger(getLogLevel(options))
   const showScript = options.scripts
   log.info(

--- a/src/replace-positional-args.js
+++ b/src/replace-positional-args.js
@@ -1,0 +1,36 @@
+// Loops over script tokens and replace any position args where positional args are denoted by $<number> and are 1
+// indexed (like bash scripts), eg `echo hello $1 world`
+// eslint-disable-next-line complexity
+function replacePositionalArgs(script, args) {
+  if (!script) {
+    return [script, args]
+  }
+  const scriptTokens = script.split(' ')
+  const usedArgs = []
+  for (const [i, token] of scriptTokens.entries()) {
+    if (token[0] !== '$') {
+      // eslint-disable-next-line no-continue
+      continue
+    }
+    const argIndex = parseInt(token.slice(1), 10)
+    const arg = args[argIndex]
+    if (!arg) {
+      throw new Error(`Argument $${argIndex} not specified`)
+    }
+    scriptTokens[i] = args[argIndex]
+    usedArgs.push(argIndex)
+  }
+  const reducedArgs = args.filter((_, i) => !usedArgs.includes(i))
+
+  // Remove arguments entirely if all arguments were positional
+  if (reducedArgs[0] === '--' && reducedArgs.length === 1 && args.length > 1) {
+    reducedArgs.pop()
+  }
+  const newScript = scriptTokens.join(' ')
+
+  return [newScript, reducedArgs]
+}
+
+module.exports = {
+  replacePositionalArgs,
+}

--- a/src/replace-positional-args.js
+++ b/src/replace-positional-args.js
@@ -8,13 +8,13 @@ function replacePositionalArgs(script, args) {
   const scriptTokens = script.split(' ')
   const usedArgs = []
   for (const [i, token] of scriptTokens.entries()) {
-    if (token[0] !== '$') {
+    if (!token.startsWith('$')) {
       // eslint-disable-next-line no-continue
       continue
     }
     const argIndex = parseInt(token.slice(1), 10)
     const arg = args[argIndex]
-    if (!arg) {
+    if (typeof arg === 'undefined') {
       throw new Error(`Argument $${argIndex} not specified`)
     }
     scriptTokens[i] = args[argIndex]


### PR DESCRIPTION
**Summary**
It is often useful to specify positional arguments at script call time rather than generate time. The following is now supported for example.

package-scripts.js
```
module.exports = {scripts: {default: 'echo "hello $1 world"''}}
```

Which would resolve to `echo "hello big world"` when invoked with `nps default -- big`. Additionally, positional arguments can be specified in any order, and are 1-indexed according to bash convention.

**Test Plan**
- Wrote unit tests

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
