### PR TITLE
[PATCH] Be robust when "named argument" doesn't exist

### DIFF
--- a/src/__tests__/replace-positional-args.js
+++ b/src/__tests__/replace-positional-args.js
@@ -24,8 +24,12 @@ test('should allow using positional args multiple times', () => {
   ).toEqual(['foobar foo bar foo', []])
 })
 
-test('should throw if positional args required but not specified', () => {
-  expect(() => replacePositionalArgs('foobar $2 $1', [])).toThrow(
-    'Argument $2 not specified',
-  )
+test('should not throw if positional args required but not specified', () => {
+  expect(() => replacePositionalArgs('foobar $2 $1', [])).not.toThrow()
+})
+
+test('should allow mixing positional args and environment variables', () => {
+  expect(
+    replacePositionalArgs('foobar $1 $FOO $2 $1', ['--', 'foo', 'bar']),
+  ).toEqual(['foobar foo $FOO bar foo', []])
 })

--- a/src/replace-positional-args.js
+++ b/src/replace-positional-args.js
@@ -15,7 +15,8 @@ function replacePositionalArgs(script, args) {
     const argIndex = parseInt(token.slice(1), 10)
     const arg = args[argIndex]
     if (typeof arg === 'undefined') {
-      throw new Error(`Argument $${argIndex} not specified`)
+      // eslint-disable-next-line no-continue
+      continue
     }
     scriptTokens[i] = args[argIndex]
     usedArgs.push(argIndex)


### PR DESCRIPTION
**Summary**
The issue with the way positional args was defined is that the format conflicts with environment variables and nps was throwing an error when an environment variable was used, eg. consider a script that uses `$FOO`. When a token with the `$` prefix is not found in the args, just ignore it and continue.

**Test Plan**
- Updated tests

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
